### PR TITLE
Add signed view toggle and reorder run controls

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -38,6 +38,7 @@ pub(super) enum MemRegion {
 pub(super) enum RunButton {
     View,
     Format,
+    Sign,
     Bytes,
     Region,
     State,
@@ -72,6 +73,7 @@ pub struct App {
     pub(super) mem_region: MemRegion,
     pub(super) show_registers: bool,
     pub(super) show_hex: bool,
+    pub(super) show_signed: bool,
     pub(super) imem_width: u16,
     pub(super) hover_imem_bar: bool,
     pub(super) imem_drag: bool,
@@ -127,6 +129,7 @@ impl App {
             mem_region: MemRegion::Data,
             show_registers: true,
             show_hex: true,
+            show_signed: false,
             imem_width: 38,
             hover_imem_bar: false,
             imem_drag: false,

--- a/src/ui/input/mouse.rs
+++ b/src/ui/input/mouse.rs
@@ -195,6 +195,9 @@ fn handle_run_status_click(app: &mut App, me: MouseEvent, area: Rect) {
             RunButton::Format => {
                 app.show_hex = !app.show_hex;
             }
+            RunButton::Sign => {
+                app.show_signed = !app.show_signed;
+            }
             RunButton::Bytes => {
                 app.mem_view_bytes = match app.mem_view_bytes {
                     4 => 2,
@@ -257,6 +260,7 @@ fn run_status_area(area: Rect) -> Rect {
 fn run_status_hit(app: &App, status: Rect, col: u16) -> Option<RunButton> {
     let view_text = if app.show_registers { "REGS" } else { "RAM" };
     let fmt_text = if app.show_hex { "HEX" } else { "DEC" };
+    let sign_text = if app.show_signed { "SGN" } else { "UNS" };
     let bytes_text = match app.mem_view_bytes {
         4 => "4B",
         2 => "2B",
@@ -282,19 +286,22 @@ fn run_status_hit(app: &App, status: Rect, col: u16) -> Option<RunButton> {
     skip(&mut pos, "View ");
     let (view_start, view_end) = range(&mut pos, view_text);
 
-    skip(&mut pos, "  Format ");
-    let (fmt_start, fmt_end) = range(&mut pos, fmt_text);
-
-    let (bytes_start, bytes_end) = if !app.show_registers {
-        skip(&mut pos, "  Bytes ");
-        range(&mut pos, bytes_text)
+    let (region_start, region_end) = if !app.show_registers {
+        skip(&mut pos, "  Region ");
+        range(&mut pos, region_text)
     } else {
         (0, 0)
     };
 
-    let (region_start, region_end) = if !app.show_registers {
-        skip(&mut pos, "  Region ");
-        range(&mut pos, region_text)
+    skip(&mut pos, "  Format ");
+    let (fmt_start, fmt_end) = range(&mut pos, fmt_text);
+
+    skip(&mut pos, "  Sign ");
+    let (sign_start, sign_end) = range(&mut pos, sign_text);
+
+    let (bytes_start, bytes_end) = if !app.show_registers {
+        skip(&mut pos, "  Bytes ");
+        range(&mut pos, bytes_text)
     } else {
         (0, 0)
     };
@@ -304,12 +311,14 @@ fn run_status_hit(app: &App, status: Rect, col: u16) -> Option<RunButton> {
 
     if col >= view_start && col < view_end {
         Some(RunButton::View)
-    } else if col >= fmt_start && col < fmt_end {
-        Some(RunButton::Format)
-    } else if !app.show_registers && col >= bytes_start && col < bytes_end {
-        Some(RunButton::Bytes)
     } else if !app.show_registers && col >= region_start && col < region_end {
         Some(RunButton::Region)
+    } else if col >= fmt_start && col < fmt_end {
+        Some(RunButton::Format)
+    } else if col >= sign_start && col < sign_end {
+        Some(RunButton::Sign)
+    } else if !app.show_registers && col >= bytes_start && col < bytes_end {
+        Some(RunButton::Bytes)
     } else if col >= state_start && col < state_end {
         Some(RunButton::State)
     } else {

--- a/src/ui/view/run.rs
+++ b/src/ui/view/run.rs
@@ -74,6 +74,8 @@ pub(super) fn render_run(f: &mut Frame, area: Rect, app: &App) {
                 };
                 let val_str = if app.show_hex {
                     format!("0x{val:08x}")
+                } else if app.show_signed {
+                    format!("{}", val as i32)
                 } else {
                     format!("{val}")
                 };
@@ -93,6 +95,8 @@ pub(super) fn render_run(f: &mut Frame, area: Rect, app: &App) {
                 };
                 let val_str = if app.show_hex {
                     format!("0x{val:08x}")
+                } else if app.show_signed {
+                    format!("{}", val as i32)
                 } else {
                     format!("{val}")
                 };
@@ -125,6 +129,8 @@ pub(super) fn render_run(f: &mut Frame, area: Rect, app: &App) {
                         let w = app.mem.load32(addr);
                         if app.show_hex {
                             format!("0x{w:08x}")
+                        } else if app.show_signed {
+                            format!("{}", w as i32)
                         } else {
                             format!("{w}")
                         }
@@ -133,6 +139,8 @@ pub(super) fn render_run(f: &mut Frame, area: Rect, app: &App) {
                         let w = app.mem.load16(addr);
                         if app.show_hex {
                             format!("0x{w:04x}")
+                        } else if app.show_signed {
+                            format!("{}", (w as i16))
                         } else {
                             format!("{w}")
                         }
@@ -141,6 +149,8 @@ pub(super) fn render_run(f: &mut Frame, area: Rect, app: &App) {
                         let w = app.mem.load8(addr);
                         if app.show_hex {
                             format!("0x{w:02x}")
+                        } else if app.show_signed {
+                            format!("{}", (w as i8))
                         } else {
                             format!("{w}")
                         }
@@ -182,6 +192,8 @@ pub(super) fn render_run(f: &mut Frame, area: Rect, app: &App) {
             let marker = if addr == app.cpu.pc { "▶" } else { " " };
             let val_str = if app.show_hex {
                 format!("0x{w:08x}")
+            } else if app.show_signed {
+                format!("{}", w as i32)
             } else {
                 format!("{w}")
             };
@@ -254,6 +266,11 @@ fn render_run_status(f: &mut Frame, area: Rect, app: &App) {
     } else {
         ("DEC", Color::Cyan)
     };
+    let (sign_text, sign_color) = if app.show_signed {
+        ("SGN", Color::LightGreen)
+    } else {
+        ("UNS", Color::LightBlue)
+    };
     let (run_text, run_color) = if app.is_running {
         ("RUN", Color::Green)
     } else {
@@ -278,13 +295,35 @@ fn render_run_status(f: &mut Frame, area: Rect, app: &App) {
             view_color,
             app.hover_run_button == Some(RunButton::View),
         ),
-        Span::raw("  Format "),
-        button(
-            fmt_text,
-            fmt_color,
-            app.hover_run_button == Some(RunButton::Format),
-        ),
     ];
+
+    if !app.show_registers {
+        let (region_text, region_color) = match app.mem_region {
+            MemRegion::Data => ("DATA", Color::Yellow),
+            MemRegion::Stack => ("STACK", Color::LightBlue),
+            MemRegion::Custom => ("ADDR", Color::Gray),
+        };
+        spans.push(Span::raw("  Region "));
+        spans.push(button(
+            region_text,
+            region_color,
+            app.hover_run_button == Some(RunButton::Region),
+        ));
+    }
+
+    spans.push(Span::raw("  Format "));
+    spans.push(button(
+        fmt_text,
+        fmt_color,
+        app.hover_run_button == Some(RunButton::Format),
+    ));
+
+    spans.push(Span::raw("  Sign "));
+    spans.push(button(
+        sign_text,
+        sign_color,
+        app.hover_run_button == Some(RunButton::Sign),
+    ));
 
     if !app.show_registers {
         let bytes_text = match app.mem_view_bytes {
@@ -297,17 +336,6 @@ fn render_run_status(f: &mut Frame, area: Rect, app: &App) {
             bytes_text,
             Color::Yellow,
             app.hover_run_button == Some(RunButton::Bytes),
-        ));
-        let (region_text, region_color) = match app.mem_region {
-            MemRegion::Data => ("DATA", Color::Yellow),
-            MemRegion::Stack => ("STACK", Color::LightBlue),
-            MemRegion::Custom => ("ADDR", Color::Gray),
-        };
-        spans.push(Span::raw("  Region "));
-        spans.push(button(
-            region_text,
-            region_color,
-            app.hover_run_button == Some(RunButton::Region),
         ));
     }
 


### PR DESCRIPTION

- add signed/unsigned memory view toggle to run controls
- reorder RAM view toggles to view, region, format, sign, bytes, state
- display register and memory values as signed when selected
