### PR TITLE
Halt execution after syscalls and block further stepping

### DIFF
--- a/src/falcon/exec.rs
+++ b/src/falcon/exec.rs
@@ -173,9 +173,8 @@ pub fn step<B: Bus>(cpu: &mut Cpu, mem: &mut B, console: &mut Console) -> bool {
 
         Instruction::Ecall => {
             let code = cpu.read(17);
-            if !handle_syscall(code, cpu, mem, console) {
-                return false;
-            }
+            let _ = handle_syscall(code, cpu, mem, console);
+            return false;
         }
         Instruction::Ebreak => return false, // HALT
         _ => {}
@@ -201,7 +200,7 @@ pub fn run<B: crate::falcon::memory::Bus>(
 mod tests {
     use super::*;
     use crate::falcon::encoder;
-    use crate::falcon::{instruction::Instruction, Ram};
+    use crate::falcon::{Ram, instruction::Instruction};
 
     #[test]
     fn ebreak_halts() {
@@ -243,7 +242,7 @@ mod tests {
         cpu.write(17, 1);
         let inst = encoder::encode(Instruction::Ecall).unwrap();
         mem.store32(0, inst);
-        assert!(step(&mut cpu, &mut mem, &mut console));
+        assert!(!step(&mut cpu, &mut mem, &mut console));
         assert_eq!(cpu.stdout, b"42");
     }
 
@@ -261,7 +260,7 @@ mod tests {
         cpu.write(17, 2);
         let inst = encoder::encode(Instruction::Ecall).unwrap();
         mem.store32(0, inst);
-        assert!(step(&mut cpu, &mut mem, &mut console));
+        assert!(!step(&mut cpu, &mut mem, &mut console));
         assert_eq!(cpu.stdout, b"hi");
     }
 
@@ -274,7 +273,7 @@ mod tests {
         cpu.write(17, 3);
         let inst = encoder::encode(Instruction::Ecall).unwrap();
         mem.store32(0, inst);
-        assert!(step(&mut cpu, &mut mem, &mut console));
+        assert!(!step(&mut cpu, &mut mem, &mut console));
         assert_eq!(cpu.read(10), 123);
     }
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1,8 +1,8 @@
 use super::{
+    console::Console,
     editor::Editor,
     input::{handle_key, handle_mouse},
     view::ui,
-    console::Console,
 };
 use crate::falcon::{self, Cpu, Ram};
 use crossterm::{
@@ -263,6 +263,7 @@ impl App {
         };
         if !alive {
             self.is_running = false;
+            self.faulted = true;
         }
     }
 }

--- a/src/ui/input/keyboard.rs
+++ b/src/ui/input/keyboard.rs
@@ -20,9 +20,6 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> io::Result<bool> {
                 let line = std::mem::take(&mut app.console.current);
                 app.console.push_input(line);
                 app.console.reading = false;
-                // Resume execution after providing input
-                app.is_running = true;
-                app.single_step();
             }
             _ => {}
         }
@@ -259,7 +256,9 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> io::Result<bool> {
 
                 // Run controls
                 (KeyCode::Char('s'), Tab::Run) => {
-                    app.single_step();
+                    if !app.faulted {
+                        app.single_step();
+                    }
                 }
                 (KeyCode::Char('r'), Tab::Run) => {
                     if !app.faulted {


### PR DESCRIPTION

- Stop the CPU after executing any syscall and treat it as a fault
- Mark application as faulted when a step halts
- Prevent stepping after faults and remove automatic resume after console input
