### PR TITLE
Fix console read to resume execution

### DIFF
--- a/src/falcon/syscall.rs
+++ b/src/falcon/syscall.rs
@@ -46,6 +46,8 @@ pub fn handle_syscall<B: Bus>(
                     addr = addr.wrapping_add(1);
                 }
                 mem.store8(addr, 0); // NUL
+                                     // Input has been consumed; stop requesting console input
+                console.reading = false;
                 true
             } else {
                 console.reading = true;
@@ -58,4 +60,3 @@ pub fn handle_syscall<B: Bus>(
         }
     }
 }
-

--- a/src/ui/input/keyboard.rs
+++ b/src/ui/input/keyboard.rs
@@ -20,6 +20,8 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> io::Result<bool> {
                 let line = std::mem::take(&mut app.console.current);
                 app.console.push_input(line);
                 app.console.reading = false;
+                // Resume CPU execution after providing input
+                app.is_running = true;
             }
             _ => {}
         }


### PR DESCRIPTION

- resume emulator after providing console input
- clear console reading flag after syscall consumes input
