### PR TITLE
Document console syscalls

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,9 @@ Labels (`label:`) can be defined in any segment. To load a label address, use th
 - `la rd, label` → loads the address of `label`
 - `push rs` → `addi sp, sp, -4` ; `sw rs, 0(sp)`
 - `pop rd` → `lw rd, 0(sp)` ; `addi sp, sp, 4`
+- `print rd` → sets `a7=1`, prints the value in `rd`
+- `printString label|rd` → sets `a7=2`, prints string at label/address
+- `read` → sets `a7=3`, reads input into memory pointed by `a0`
 
 ## Registers and Memory
 
@@ -128,6 +131,7 @@ The emulator executes instructions while `step` returns `true`.
 
 ### Console
 
-The Run tab now features a bottom console where syscalls `print`/`read` perform I/O.
-Use it to view program output or type responses. Scroll with `Ctrl+Up/Down` to review
-previous lines.
+The Run tab now features a bottom console where syscalls `print`, `printString` and
+`read` perform I/O. `print rd` outputs the decimal value of a register, `printString
+label|rd` prints a NUL-terminated string and `read` stores a line at the address in
+`a0`. Scroll with `Ctrl+Up/Down` to review previous lines.

--- a/docs/format.md
+++ b/docs/format.md
@@ -196,9 +196,15 @@ Other formats (I, S, B, U, J) rearrange fields and immediates.
   - `li rd, imm12` → `addi rd, x0, imm`
   - `subi rd, rs1, imm` → `addi rd, rs1, -imm`
   - `j label` → `jal x0, label`
+  - `call label` → `jal ra, label`
   - `jr rs1` → `jalr x0, rs1, 0`
   - `ret` → `jalr x0, ra, 0`
   - `la rd, label` → emits `lui`/`addi` to load a data address
+  - `push rs` → `addi sp, sp, -4` ; `sw rs, 0(sp)`
+  - `pop rd` → `lw rd, 0(sp)` ; `addi sp, sp, 4`
+  - `print rd` → `a7=1, a0=rd, ecall`
+  - `printString label|rd` → `a7=2, a0=addr, ecall`
+  - `read` → `a7=3, a0=dest, ecall`
 
 ## Example Code
 

--- a/src/ui/view/docs.rs
+++ b/src/ui/view/docs.rs
@@ -1,6 +1,6 @@
-use ratatui::Frame;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::Frame;
 use std::cmp::min;
 
 use super::App;
@@ -52,5 +52,5 @@ System:
 Notes:
 • PC advances +4 each instruction. Branch/JAL immediates are byte offsets (must be even).
 • Loads/Stores syntax: imm(rs1). Labels supported by 2-pass assembler.
-• Pseudoinstructions: nop, mv, li(12-bit), j, jr, ret, subi.
+• Pseudoinstructions: nop, mv, li(12-bit), j, call, jr, ret, subi, la, push, pop, print, printString, read.
 "#;


### PR DESCRIPTION

- document `print`, `printString` and `read` pseudo-instructions
- expand UI docs tab with new pseudoinstructions
- describe console behavior for these syscalls
