### PR TITLE
Add string format option, halt instruction, and console clear

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Implements the essential subset of **RV32I**:
 - **Branches:** `BEQ, BNE, BLT, BGE, BLTU, BGEU`
 - **U/J:** `LUI, AUIPC, JAL`
 - **JALR`
-- **SYSTEM:** `ECALL`, `EBREAK` (treated as HALT)
+- **SYSTEM:** `ECALL`, `HALT`
 
 *Not implemented:* FENCE/CSR and floating point.
 
@@ -115,7 +115,7 @@ load_words(&mut mem, cpu.pc, &prog.text);
 load_bytes(&mut mem, prog.data_base, &prog.data);
 ```
 
-The emulator executes instructions while `step` returns `true`.
+The emulator executes instructions while `step` returns `true`; encountering `halt` or an unknown syscall stops execution.
 
 # Examples
 ## Code editor

--- a/docs/format.md
+++ b/docs/format.md
@@ -18,7 +18,7 @@ Supports the essential subset of **RV32I**:
 - **Branches:** `BEQ, BNE, BLT, BGE, BLTU, BGEU`
 - **U/J:** `LUI, AUIPC, JAL`
 - **JALR**
-- **SYSTEM:** `ECALL`, `EBREAK` (interpreted as HALT)
+- **SYSTEM:** `ECALL`, `HALT`
 
 *Not implemented:* FENCE/CSR instructions and floating point.
 
@@ -170,7 +170,7 @@ Other formats (I, S, B, U, J) rearrange fields and immediates.
 
 ### SYSTEM (opcode 0x73)
 
-- `ECALL` (`0x00000073`) and `EBREAK` (`0x00100073`) halt execution.
+- `ECALL` (`0x00000073`) and `HALT` (`0x00100073`) halt execution.
 
 ## Assembler Rules
 
@@ -202,6 +202,7 @@ Other formats (I, S, B, U, J) rearrange fields and immediates.
   - `la rd, label` → emits `lui`/`addi` to load a data address
   - `push rs` → `addi sp, sp, -4` ; `sw rs, 0(sp)`
   - `pop rd` → `lw rd, 0(sp)` ; `addi sp, sp, 4`
+  - `halt` → `0x00100073` (stops execution)
   - `print rd` → `a7=1, a0=rd, ecall`
   - `printString label|rd` → `a7=2, a0=addr, ecall`
   - `read` → `a7=3, a0=dest, ecall`

--- a/instructions.set
+++ b/instructions.set
@@ -29,7 +29,7 @@ docs/
 - **Branches:** `BEQ, BNE, BLT, BGE, BLTU, BGEU`
 - **U/J:** `LUI, AUIPC, JAL`
 - **JALR**
-- **SYSTEM:** `ECALL`, `EBREAK`
+- **SYSTEM:** `ECALL`, `HALT`
 
 *Missing:* FENCE/CSR and floating point.
 
@@ -48,4 +48,4 @@ Requires [Rust](https://rustup.rs).
 cargo run
 ```
 
-The example program in `main.rs` assembles a small routine, loads code and data into memory and executes until it encounters `ecall`.
+The example program in `main.rs` assembles a small routine, loads code and data into memory and executes until it encounters `halt` or an unknown syscall.

--- a/src/falcon/asm/mod.rs
+++ b/src/falcon/asm/mod.rs
@@ -578,11 +578,11 @@ fn parse_instr(s: &str, pc: u32, labels: &HashMap<String, u32>) -> Result<Instru
             }
             Ok(Ecall)
         }
-        "ebreak" => {
+        "halt" => {
             if !ops.is_empty() {
-                return Err("ebreak takes no operands".into());
+                return Err("halt takes no operands".into());
             }
-            Ok(Ebreak)
+            Ok(Halt)
         }
 
         _ => Err(format!("unsupported mnemonic: {mnemonic}")),
@@ -934,10 +934,10 @@ mod tests {
     #[test]
     fn call_expands_to_jal_ra() {
         // Simple program with a call to a local label
-        let asm = ".text\ncall func\nfunc: ebreak";
+        let asm = ".text\ncall func\nfunc: halt";
         let prog = assemble(asm, 0).expect("assemble");
 
-        // Should emit: JAL ra, func; EBREAK
+        // Should emit: JAL ra, func; HALT
         assert_eq!(prog.text.len(), 2);
 
         let expected_jal = encode(Instruction::Jal { rd: 1, imm: 4 }).expect("encode jal");

--- a/src/falcon/decoder/itype.rs
+++ b/src/falcon/decoder/itype.rs
@@ -64,7 +64,10 @@ pub(super) fn decode_auipc(word:u32)->Result<Instruction,&'static str>{
     Ok(Instruction::Auipc{ rd, imm })
 }
 
-pub(super) fn decode_system(_word:u32)->Result<Instruction,&'static str>{
-    // MVP: treat ECALL/EBREAK as halt
-    Ok(Instruction::Ecall)
+pub(super) fn decode_system(word: u32) -> Result<Instruction, &'static str> {
+    match word {
+        0x0000_0073 => Ok(Instruction::Ecall),
+        0x0010_0073 => Ok(Instruction::Halt),
+        _ => Err("Unknown system instruction"),
+    }
 }

--- a/src/falcon/decoder/mod.rs
+++ b/src/falcon/decoder/mod.rs
@@ -41,7 +41,8 @@ pub fn disasm(word: u32) -> String {
             Instruction::Jalr{rd,rs1,imm}  => format!("jalr x{rd}, x{rs1}, {}", imm),
             Instruction::Lw  {rd,rs1,imm}  => format!("lw   x{rd}, {}(x{rs1})", imm),
             Instruction::Sw  {rs2,rs1,imm} => format!("sw   x{rs2}, {}(x{rs1})", imm),
-            Instruction::Ecall             => "ecall".into(),
+            Instruction::Ecall => "ecall".into(),
+            Instruction::Halt => "halt".into(),
             other => format!("{other:?}"), // fallback para o resto
         },
         Err(e) => format!(".word 0x{word:08x} ; {e}"),

--- a/src/falcon/encoder/mod.rs
+++ b/src/falcon/encoder/mod.rs
@@ -105,6 +105,6 @@ pub fn encode(inst: Instruction) -> Result<u32, &'static str> {
         Jalr{rd,rs1,imm} => i(imm, rs1 as u32, 0x0, rd as u32, OPC_JALR as u32),
 
         Ecall => 0x00000073,  // SYSTEM/ECALL
-        Ebreak => 0x00100073, // SYSTEM/EBREAK
+        Halt => 0x00100073,   // SYSTEM/HALT
     })
 }

--- a/src/falcon/exec.rs
+++ b/src/falcon/exec.rs
@@ -190,8 +190,8 @@ pub fn step<B: Bus>(cpu: &mut Cpu, mem: &mut B, console: &mut Console) -> bool {
             }
             return cont;
         }
-        Instruction::Ebreak => {
-            console.push_error(format!("EBREAK at 0x{pc:08X}"));
+        Instruction::Halt => {
+            console.push_error(format!("HALT at 0x{pc:08X}"));
             return false;
         }
         _ => {}
@@ -221,11 +221,11 @@ mod tests {
     use crate::falcon::{Ram, instruction::Instruction};
 
     #[test]
-    fn ebreak_halts() {
+    fn halt_halts() {
         let mut cpu = Cpu::default();
         let mut mem = Ram::new(4);
         let mut console = crate::ui::Console::default();
-        let inst = encoder::encode(Instruction::Ebreak).unwrap();
+        let inst = encoder::encode(Instruction::Halt).unwrap();
         mem.store32(0, inst);
         assert!(!step(&mut cpu, &mut mem, &mut console));
     }
@@ -243,9 +243,9 @@ mod tests {
             imm: 0,
         })
         .unwrap();
-        let ebreak = encoder::encode(Instruction::Ebreak).unwrap();
+        let halt = encoder::encode(Instruction::Halt).unwrap();
         mem.store32(0, sw);
-        mem.store32(4, ebreak);
+        mem.store32(4, halt);
         assert!(step(&mut cpu, &mut mem, &mut console));
         assert_eq!(mem.load32(0x20), 0xDEADBEEF);
         assert!(!step(&mut cpu, &mut mem, &mut console));
@@ -309,9 +309,9 @@ mod tests {
         cpu.write(10, addr);
         cpu.write(17, 3);
         let ecall = encoder::encode(Instruction::Ecall).unwrap();
-        let ebreak = encoder::encode(Instruction::Ebreak).unwrap();
+        let halt = encoder::encode(Instruction::Halt).unwrap();
         mem.store32(0, ecall);
-        mem.store32(4, ebreak);
+        mem.store32(4, halt);
 
         assert!(!step(&mut cpu, &mut mem, &mut console));
         assert_eq!(cpu.pc, 0);

--- a/src/falcon/instruction.rs
+++ b/src/falcon/instruction.rs
@@ -33,6 +33,6 @@ pub enum Instruction {
     Lui{ rd:u8, imm:i32 }, Auipc{ rd:u8, imm:i32 },
     Jal{ rd:u8, imm:i32 },
 
-    // System (MVP: only ecall/ebreak as "halt")
-    Ecall, Ebreak,
+    // System (MVP: ecall and halt)
+    Ecall, Halt,
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -36,6 +36,13 @@ pub(super) enum MemRegion {
 }
 
 #[derive(PartialEq, Eq, Copy, Clone)]
+pub(super) enum FormatMode {
+    Hex,
+    Dec,
+    Str,
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
 pub(super) enum RunButton {
     View,
     Format,
@@ -73,7 +80,7 @@ pub struct App {
     pub(super) mem_view_bytes: u32,
     pub(super) mem_region: MemRegion,
     pub(super) show_registers: bool,
-    pub(super) show_hex: bool,
+    pub(super) fmt_mode: FormatMode,
     pub(super) show_signed: bool,
     pub(super) imem_width: u16,
     pub(super) hover_imem_bar: bool,
@@ -82,6 +89,7 @@ pub struct App {
     pub(super) imem_width_start: u16,
     pub(super) console_height: u16,
     pub(super) hover_console_bar: bool,
+    pub(super) hover_console_clear: bool,
     pub(super) console_drag: bool,
     pub(super) console_drag_start_y: u16,
     pub(super) console_height_start: u16,
@@ -137,7 +145,7 @@ impl App {
             mem_view_bytes: 4,
             mem_region: MemRegion::Data,
             show_registers: true,
-            show_hex: true,
+            fmt_mode: FormatMode::Hex,
             show_signed: false,
             imem_width: 38,
             hover_imem_bar: false,
@@ -146,6 +154,7 @@ impl App {
             imem_width_start: 38,
             console_height: 5,
             hover_console_bar: false,
+            hover_console_clear: false,
             console_drag: false,
             console_drag_start_y: 0,
             console_height_start: 5,

--- a/src/ui/console.rs
+++ b/src/ui/console.rs
@@ -48,5 +48,10 @@ impl Console {
     pub fn read_line(&mut self) -> Option<String> {
         self.input.pop_front()
     }
+
+    pub fn clear(&mut self) {
+        self.lines.clear();
+        self.scroll = 0;
+    }
 }
 

--- a/src/ui/view/docs.rs
+++ b/src/ui/view/docs.rs
@@ -47,10 +47,12 @@ Jumps:
   JAL (0x6F), JALR (0x67)
 
 System:
-  ECALL (0x00000073), EBREAK (0x00100073)
+  ECALL (0x00000073), HALT (0x00100073)
 
 Notes:
 • PC advances +4 each instruction. Branch/JAL immediates are byte offsets (must be even).
 • Loads/Stores syntax: imm(rs1). Labels supported by 2-pass assembler.
 • Pseudoinstructions: nop, mv, li(12-bit), j, call, jr, ret, subi, la, push, pop, print, printString, read.
+• Syscalls: `print rd` prints the value of `rd`, `printString label|rd` prints a NUL-terminated string,
+  `read` reads a line into the address in `a0`. Use `halt` to stop execution.
 "#;

--- a/src/ui/view/editor.rs
+++ b/src/ui/view/editor.rs
@@ -28,7 +28,7 @@ pub(super) fn render_editor_status(f: &mut Frame, area: Rect, app: &App) {
     let build = Line::from(vec![Span::raw("Build: "), compile_span]);
 
     let commands = Line::from(
-        "Commands: Esc=Command  |  i=Insert  |  Ctrl+R=Assemble  |  Ctrl+O=Import  |  Ctrl+S=Export",
+        "Commands: Esc=Command  |  Ctrl+R=Assemble  |  Ctrl+O=Import  |  Ctrl+S=Export",
     );
 
     let para = Paragraph::new(vec![mode, build, commands]).block(


### PR DESCRIPTION

- support viewing registers and memory as ASCII strings via new format toggle
- add clear button to runtime console and streamline editor command hints
- replace `ebreak` with `halt` instruction and document print/read syscalls

