### PR TITLE
Improve error handling with thiserror and Results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,7 @@ dependencies = [
  "crossterm 0.29.0",
  "ratatui",
  "rfd",
+ "thiserror",
 ]
 
 [[package]]
@@ -1652,6 +1653,26 @@ dependencies = [
  "once_cell",
  "rustix 1.0.8",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ ratatui = { version = "0.28", features = ["all-widgets"] }
 crossterm = "0.29"
 rfd = "0.15"
 arboard = "3"
+thiserror = "1"
 
 [profile.release]
 opt-level = 3        # máxima otimização de código

--- a/src/falcon/decoder/btype.rs
+++ b/src/falcon/decoder/btype.rs
@@ -1,7 +1,7 @@
-use crate::falcon::instruction::Instruction;
+use crate::falcon::{instruction::Instruction, errors::FalconError};
 use super::{bits, sext};
 
-pub(super) fn decode(word:u32)->Result<Instruction,&'static str>{
+pub(super) fn decode(word:u32)->Result<Instruction,FalconError>{
     let funct3 = bits(word, 14, 12) as u8;
     let rs1 = bits(word, 19, 15) as u8;
     let rs2 = bits(word, 24, 20) as u8;
@@ -20,6 +20,6 @@ pub(super) fn decode(word:u32)->Result<Instruction,&'static str>{
         0x5 => Instruction::Bge{rs1,rs2,imm},
         0x6 => Instruction::Bltu{rs1,rs2,imm},
         0x7 => Instruction::Bgeu{rs1,rs2,imm},
-        _ => return Err("Invalid branch"),
+        _ => return Err(FalconError::Decode("Invalid branch")),
     })
 }

--- a/src/falcon/decoder/jtype.rs
+++ b/src/falcon/decoder/jtype.rs
@@ -1,7 +1,7 @@
-use crate::falcon::instruction::Instruction;
+use crate::falcon::{instruction::Instruction, errors::FalconError};
 use super::{bits, sext};
 
-pub(super) fn decode_jal(word:u32)->Result<Instruction,&'static str>{
+pub(super) fn decode_jal(word:u32)->Result<Instruction,FalconError>{
     let rd  = bits(word, 11, 7) as u8;
     // J-imm: [20|10:1|11|19:12] << 1
     let imm_bits =

--- a/src/falcon/decoder/mod.rs
+++ b/src/falcon/decoder/mod.rs
@@ -4,7 +4,7 @@ mod stype;
 mod btype;
 mod jtype;
 
-use crate::falcon::instruction::Instruction;
+use crate::falcon::{instruction::Instruction, errors::FalconError};
 use crate::falcon::arch::*;
 
 #[inline] fn bits(v:u32, hi:u8, lo:u8)->u32 { (v >> lo) & ((1u32 << (hi-lo+1)) - 1) }
@@ -13,7 +13,7 @@ use crate::falcon::arch::*;
     ((v << shift) as i32) >> shift
 }
 
-pub fn decode(word: u32) -> Result<Instruction, &'static str> {
+pub fn decode(word: u32) -> Result<Instruction, FalconError> {
     let opcode = bits(word, 6, 0) as u8;
     match opcode {
         OPC_RTYPE  => rtype::decode(word),
@@ -26,7 +26,7 @@ pub fn decode(word: u32) -> Result<Instruction, &'static str> {
         OPC_LUI    => itype::decode_lui(word),
         OPC_AUIPC  => itype::decode_auipc(word),
         OPC_SYSTEM => itype::decode_system(word),
-        _ => Err("unknown opcode"),
+        _ => Err(FalconError::Decode("unknown opcode")),
     }
 }
 

--- a/src/falcon/decoder/rtype.rs
+++ b/src/falcon/decoder/rtype.rs
@@ -1,7 +1,7 @@
-use crate::falcon::instruction::Instruction;
-use super::{bits};
+use crate::falcon::{instruction::Instruction, errors::FalconError};
+use super::bits;
 
-pub(super) fn decode(word:u32)->Result<Instruction,&'static str>{
+pub(super) fn decode(word:u32)->Result<Instruction,FalconError>{
     let rd  = bits(word, 11, 7) as u8;
     let funct3 = bits(word, 14, 12) as u8;
     let rs1 = bits(word, 19, 15) as u8;
@@ -27,6 +27,6 @@ pub(super) fn decode(word:u32)->Result<Instruction,&'static str>{
         (0x01, 0x5) => Instruction::Divu{rd,rs1,rs2},
         (0x01, 0x6) => Instruction::Rem{rd,rs1,rs2},
         (0x01, 0x7) => Instruction::Remu{rd,rs1,rs2},
-        _ => return Err("Invalid R-type"),
+        _ => return Err(FalconError::Decode("Invalid R-type")),
     })
 }

--- a/src/falcon/decoder/stype.rs
+++ b/src/falcon/decoder/stype.rs
@@ -1,7 +1,7 @@
-use crate::falcon::instruction::Instruction;
+use crate::falcon::{instruction::Instruction, errors::FalconError};
 use super::{bits, sext};
 
-pub(super) fn decode(word:u32)->Result<Instruction,&'static str>{
+pub(super) fn decode(word:u32)->Result<Instruction,FalconError>{
     let funct3 = bits(word, 14, 12) as u8;
     let rs1 = bits(word, 19, 15) as u8;
     let rs2 = bits(word, 24, 20) as u8;
@@ -15,6 +15,6 @@ pub(super) fn decode(word:u32)->Result<Instruction,&'static str>{
         0x0 => Instruction::Sb{rs2,rs1,imm},
         0x1 => Instruction::Sh{rs2,rs1,imm},
         0x2 => Instruction::Sw{rs2,rs1,imm},
-        _ => return Err("Invalid store"),
+        _ => return Err(FalconError::Decode("Invalid store")),
     })
 }

--- a/src/falcon/errors.rs
+++ b/src/falcon/errors.rs
@@ -1,6 +1,14 @@
-// MVP: placeholder (depois podemos trocar por thiserror)
-#[allow(dead_code)]
+use thiserror::Error;
+
+/// Errors that can occur within the Falcon emulator.
+#[derive(Error, Debug)]
 pub enum FalconError {
+    /// Problems decoding an instruction.
+    #[error("Decode error: {0}")]
     Decode(&'static str),
+
+    /// Bus or memory access errors.
+    #[error("Bus error: {0}")]
     Bus(&'static str),
 }
+

--- a/src/falcon/program/loader.rs
+++ b/src/falcon/program/loader.rs
@@ -1,19 +1,21 @@
-use crate::falcon::memory::Bus;
+use crate::falcon::{memory::Bus, errors::FalconError};
 
 /// Loads words (u32 little-endian) at `base`, contiguously, as code.
-pub fn load_words(mem: &mut impl Bus, base: u32, code: &[u32]) {
+pub fn load_words(mem: &mut impl Bus, base: u32, code: &[u32]) -> Result<(), FalconError> {
     let mut addr = base;
     for &w in code {
-        mem.store32(addr, w);
+        mem.store32(addr, w)?;
         addr = addr.wrapping_add(4);
     }
+    Ok(())
 }
 
 /// Loads raw bytes at `base`.
-pub fn load_bytes(mem: &mut impl Bus, base: u32, bytes: &[u8]) {
+pub fn load_bytes(mem: &mut impl Bus, base: u32, bytes: &[u8]) -> Result<(), FalconError> {
     let mut addr = base;
     for &b in bytes {
-        mem.store8(addr, b);
+        mem.store8(addr, b)?;
         addr = addr.wrapping_add(1);
     }
+    Ok(())
 }

--- a/src/ui/view/run.rs
+++ b/src/ui/view/run.rs
@@ -136,11 +136,11 @@ pub(super) fn render_run(f: &mut Frame, area: Rect, app: &App) {
             if addr <= max {
                 let val_str = match (bytes, app.fmt_mode) {
                     (4, FormatMode::Hex) => {
-                        let w = app.mem.load32(addr);
+                        let w = app.mem.load32(addr).unwrap_or(0);
                         format!("0x{w:08x}")
                     }
                     (4, FormatMode::Dec) => {
-                        let w = app.mem.load32(addr);
+                        let w = app.mem.load32(addr).unwrap_or(0);
                         if app.show_signed {
                             format!("{}", w as i32)
                         } else {
@@ -148,15 +148,15 @@ pub(super) fn render_run(f: &mut Frame, area: Rect, app: &App) {
                         }
                     }
                     (4, FormatMode::Str) => {
-                        let w = app.mem.load32(addr);
+                        let w = app.mem.load32(addr).unwrap_or(0);
                         ascii_bytes(&w.to_le_bytes())
                     }
                     (2, FormatMode::Hex) => {
-                        let w = app.mem.load16(addr);
+                        let w = app.mem.load16(addr).unwrap_or(0);
                         format!("0x{w:04x}")
                     }
                     (2, FormatMode::Dec) => {
-                        let w = app.mem.load16(addr);
+                        let w = app.mem.load16(addr).unwrap_or(0);
                         if app.show_signed {
                             format!("{}", (w as i16))
                         } else {
@@ -164,15 +164,15 @@ pub(super) fn render_run(f: &mut Frame, area: Rect, app: &App) {
                         }
                     }
                     (2, FormatMode::Str) => {
-                        let w = app.mem.load16(addr);
+                        let w = app.mem.load16(addr).unwrap_or(0);
                         ascii_bytes(&w.to_le_bytes())
                     }
                     (_, FormatMode::Hex) => {
-                        let w = app.mem.load8(addr);
+                        let w = app.mem.load8(addr).unwrap_or(0);
                         format!("0x{w:02x}")
                     }
                     (_, FormatMode::Dec) => {
-                        let w = app.mem.load8(addr);
+                        let w = app.mem.load8(addr).unwrap_or(0);
                         if app.show_signed {
                             format!("{}", (w as i8))
                         } else {
@@ -180,7 +180,7 @@ pub(super) fn render_run(f: &mut Frame, area: Rect, app: &App) {
                         }
                     }
                     (_, FormatMode::Str) => {
-                        let w = app.mem.load8(addr);
+                        let w = app.mem.load8(addr).unwrap_or(0);
                         ascii_bytes(&[w])
                     }
                 };
@@ -216,7 +216,7 @@ pub(super) fn render_run(f: &mut Frame, area: Rect, app: &App) {
     for off in (0..lines).map(|i| i * 4) {
         let addr = base.wrapping_add(off);
         if in_mem_range(app, addr) {
-            let w = app.mem.load32(addr);
+            let w = app.mem.load32(addr).unwrap_or(0);
             let marker = if addr == app.cpu.pc { "▶" } else { " " };
             let val_str = match app.fmt_mode {
                 FormatMode::Hex => format!("0x{w:08x}"),
@@ -263,7 +263,7 @@ pub(super) fn render_run(f: &mut Frame, area: Rect, app: &App) {
         .split(cols[2]);
 
     let (cur_word, disasm_str) = if in_mem_range(app, app.cpu.pc) {
-        let w = app.mem.load32(app.cpu.pc);
+        let w = app.mem.load32(app.cpu.pc).unwrap_or(0);
         let dis = disasm_word(w);
         (w, dis)
     } else {


### PR DESCRIPTION

- add `thiserror` and implement `FalconError` for decoding and bus errors
- switch decoder and memory interfaces to `Result`-based APIs and propagate errors
- enhance parse errors for `print`, `printString`, and `read` pseudoinstructions
