### PR TITLE
Expand README docs with platform overview

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -1,197 +1,202 @@
-# Falcon ASM — Encoding Reference and ISA (RV32I)
+# Falcon ASM format guide — RV32I in plain language
 
-This document describes what is implemented in Falcon ASM, an educational RISC‑V emulator. It covers:
+This is the companion reference for Falcon ASM, our teaching-friendly RISC-V emulator. Use it as a cheat sheet when the
+[Tutorial](Tutorial.md) shows *how* to assemble a program and you want to double-check *why* an instruction encodes a certain way.
+If you are coming from the README and feel ready to dig into the nitty-gritty, you are in the right place.
 
-- instruction formats and bit fields;
-- opcodes, `funct3` and `funct7` values used;
-- immediate ranges and alignment rules;
-- text assembler rules including labels, segments and pseudos.
+## How to read this document
 
-## Current State
+- Every section keeps the tables you need, followed by a short explanation in everyday language.
+- Head straight to [Encoding cheat sheets](#encoding-cheat-sheets) when you only need bit layouts.
+- New to the assembler directives? Jump to [Assembler behaviour and pseudo-instructions](#assembler-behaviour-and-pseudo-instructions).
+- Prefer learning by doing? Pair this guide with the [Tutorial](Tutorial.md) and try the snippets as you read.
 
-Supports the essential subset of RV32I:
+## Architecture snapshot
 
-- R-type: `ADD, SUB, AND, OR, XOR, SLL, SRL, SRA, SLT, SLTU, MUL, MULH, MULHSU, MULHU, DIV, DIVU, REM, REMU`
-- I-type (OP-IMM): `ADDI, ANDI, ORI, XORI, SLTI, SLTIU, SLLI, SRLI, SRAI`
-- Loads: `LB, LH, LW, LBU, LHU`
-- Stores: `SB, SH, SW`
-- Branches: `BEQ, BNE, BLT, BGE, BLTU, BGEU`
-- U/J: `LUI, AUIPC, JAL`
-- JALR
-- SYSTEM: `ECALL`, `HALT`
+Falcon focuses on a approachable RV32I+M subset so you can reason about each pipeline stage without being buried in extras.
 
-Not implemented: FENCE/CSR and floating point.
+- **Word size:** 32 bits.
+- **Endianness:** little-endian throughout (`{to,from}_le_bytes`).
+- **Program counter:** advances by 4 each instruction; branches and jumps are PC-relative.
+- **Registers:** hardware names `x0…x31` with the usual aliases `zero`, `ra`, `sp`, `gp`, `tp`, `t0…t6`, `s0/fp`, `s1`, `a0…a7`,
+  `s2…s11`. Writes to `x0/zero` are ignored.
 
-## Word Size, Endianness and PC
+Not yet implemented: CSR/FENCE instructions and any floating-point extension. Keeping the surface area small makes Falcon easier to
+use in class or during workshops.
 
-- Word: 32 bits
-- Endianness: little‑endian (`{to,from}_le_bytes`)
-- PC: advances by +4 per instruction. Branches and jumps use PC‑relative offsets.
+## Instruction set inside Falcon
 
-## Registers
+| Category | Instructions |
+| --- | --- |
+| R-type | `ADD`, `SUB`, `AND`, `OR`, `XOR`, `SLL`, `SRL`, `SRA`, `SLT`, `SLTU`, `MUL`, `MULH`, `MULHSU`, `MULHU`, `DIV`, `DIVU`, `REM`, `REMU` |
+| I-type (OP-IMM) | `ADDI`, `ANDI`, `ORI`, `XORI`, `SLTI`, `SLTIU`, `SLLI`, `SRLI`, `SRAI` |
+| Loads | `LB`, `LH`, `LW`, `LBU`, `LHU` |
+| Stores | `SB`, `SH`, `SW` |
+| Branches | `BEQ`, `BNE`, `BLT`, `BGE`, `BLTU`, `BGEU` |
+| Upper / jumps | `LUI`, `AUIPC`, `JAL`, `JALR` |
+| System | `ECALL`, `HALT` |
 
-- Registers `x0..x31`; writes to `x0` are ignored.
-- Assembler aliases: `zero, ra, sp, gp, tp, t0..t6, s0/fp, s1, a0..a7, s2..s11`.
+Division by zero is treated as a teaching moment: `DIV`, `DIVU`, `REM`, and `REMU` halt the emulator with a descriptive error instead
+of following the architected “divide-by-zero” results. The interruption makes it obvious something unexpected happened.
 
-## Instruction Formats (32-bit)
+## Encoding cheat sheets
 
-R-type example
+The tables below show all 32-bit layouts Falcon uses. When an instruction name appears in bold, read the note beneath the table for
+a reminder about immediate ranges or special cases.
 
-| Field  | Bits  | Description                  |
-|--------|-------|------------------------------|
-| opcode | [6:0] | major opcode                 |
-| rd     | [11:7]| destination register         |
-| funct3 |[14:12]| subtype                      |
-| rs1    |[19:15]| source register 1            |
-| rs2    |[24:20]| source register 2            |
-| funct7 |[31:25]| additional subtype           |
+### R-type (arithmetic, logic, multiply/divide)
 
-Other formats (I, S, B, U, J) rearrange fields and immediates accordingly.
+| Field  | Bits  | Description |
+| --- | --- | --- |
+| opcode | [6:0] | instruction family |
+| rd     | [11:7] | destination register |
+| funct3 | [14:12] | operation subtype |
+| rs1    | [19:15] | source register 1 |
+| rs2    | [24:20] | source register 2 |
+| funct7 | [31:25] | extra subtype / MUL/DIV selector |
 
-### I-type (OP-IMM, LOADs and JALR)
+### I-type (OP-IMM, loads, `JALR`)
 
-| Field     | Bits  |
-|-----------|-------|
-| opcode    | [6:0] |
-| rd        | [11:7]|
-| funct3    |[14:12]|
-| rs1       |[19:15]|
-| imm[11:0] |[31:20]|
+| Field | Bits |
+| --- | --- |
+| opcode | [6:0] |
+| rd | [11:7] |
+| funct3 | [14:12] |
+| rs1 | [19:15] |
+| imm[11:0] | [31:20] |
 
-- 12-bit signed immediates (-2048..2047)
-- Shifts (`SLLI/SRLI/SRAI`) use `shamt` in [24:20] and `funct7` = `0x00` (`SLLI/SRLI`) or `0x20` (`SRAI`).
+- Immediates are signed and range from -2048 to 2047.
+- Shift instructions use `shamt` in bits [24:20] with `funct7 = 0x00` (`SLLI`, `SRLI`) or `0x20` (`SRAI`).
 
-### S-type (Stores)
+### S-type (stores)
 
-| Field     | Bits  |
-|-----------|-------|
-| opcode    | [6:0] |
-| imm[4:0]  | [11:7]|
-| funct3    |[14:12]|
-| rs1       |[19:15]|
-| rs2       |[24:20]|
-| imm[11:5] |[31:25]|
+| Field | Bits |
+| --- | --- |
+| opcode | [6:0] |
+| imm[4:0] | [11:7] |
+| funct3 | [14:12] |
+| rs1 | [19:15] |
+| rs2 | [24:20] |
+| imm[11:5] | [31:25] |
 
-### B-type (Branches)
+### B-type (conditional branches)
 
-| Field     | Bits  |
-|-----------|-------|
-| opcode    | [6:0] |
-| imm[11]   | [7]   |
-| imm[4:1]  |[11:8] |
-| funct3    |[14:12]|
-| rs1       |[19:15]|
-| rs2       |[24:20]|
-| imm[10:5] |[30:25]|
-| imm[12]   |[31]   |
+| Field | Bits |
+| --- | --- |
+| opcode | [6:0] |
+| imm[11] | [7] |
+| imm[4:1] | [11:8] |
+| funct3 | [14:12] |
+| rs1 | [19:15] |
+| rs2 | [24:20] |
+| imm[10:5] | [30:25] |
+| imm[12] | [31] |
 
-- 13-bit immediates (in bytes) with bit0 = 0. The assembler computes `target_pc - instruction_pc`.
+- The assembler fills a 13-bit immediate (in bytes). Bit 0 is always zero because branch targets are word-aligned.
 
-### U-type (LUI/AUIPC)
+### U-type (`LUI`, `AUIPC`)
 
-| Field     | Bits  |
-|-----------|-------|
-| opcode    | [6:0] |
-| rd        |[11:7] |
-| imm[31:12]|[31:12]|
+| Field | Bits |
+| --- | --- |
+| opcode | [6:0] |
+| rd | [11:7] |
+| imm[31:12] | [31:12] |
 
-### J-type (JAL)
+### J-type (`JAL`)
 
-| Field     | Bits  |
-|-----------|-------|
-| opcode    | [6:0] |
-| rd        |[11:7] |
-| imm[19:12]|[19:12]|
-| imm[11]   | [20]  |
-| imm[10:1] |[30:21]|
-| imm[20]   | [31]  |
+| Field | Bits |
+| --- | --- |
+| opcode | [6:0] |
+| rd | [11:7] |
+| imm[19:12] | [19:12] |
+| imm[11] | [20] |
+| imm[10:1] | [30:21] |
+| imm[20] | [31] |
 
-- 21-bit immediates (in bytes) with bit0 = 0. The assembler computes the relative displacement.
+- The 21-bit immediate is stored in bytes; bit 0 is zero because jump targets are word-aligned.
 
-## Opcodes by Type
+## Opcode and funct reference
 
-- `OPC_RTYPE = 0x33`
-- `OPC_OPIMM = 0x13`
-- `OPC_LOAD  = 0x03`
-- `OPC_STORE = 0x23`
-- `OPC_BRANCH= 0x63`
-- `OPC_LUI   = 0x37`
-- `OPC_AUIPC = 0x17`
-- `OPC_JAL   = 0x6F`
-- `OPC_JALR  = 0x67`
-- `OPC_SYSTEM= 0x73`
+| Purpose | Value |
+| --- | --- |
+| `OPC_RTYPE` | `0x33` |
+| `OPC_OPIMM` | `0x13` |
+| `OPC_LOAD` | `0x03` |
+| `OPC_STORE` | `0x23` |
+| `OPC_BRANCH` | `0x63` |
+| `OPC_LUI` | `0x37` |
+| `OPC_AUIPC` | `0x17` |
+| `OPC_JAL` | `0x6F` |
+| `OPC_JALR` | `0x67` |
+| `OPC_SYSTEM` | `0x73` |
 
-## FUNCT3/FUNCT7
+### `funct3` and `funct7`
 
-R-type (opcode 0x33)
+**R-type (`0x33`):**
 
-- `0x0`: `ADD` (`funct7=0x00`), `SUB` (`funct7=0x20`)
-- `0x1`: `SLL`
-- `0x4`: `XOR`
-- `0x5`: `SRL` (`0x00`), `SRA` (`0x20`)
-- `0x6`: `OR`
-- `0x7`: `AND`
+- `funct3 = 0x0`: `ADD` (`funct7=0x00`), `SUB` (`funct7=0x20`)
+- `funct3 = 0x1`: `SLL`
+- `funct3 = 0x2`: `SLT`
+- `funct3 = 0x3`: `SLTU`
+- `funct3 = 0x4`: `XOR`
+- `funct3 = 0x5`: `SRL` (`funct7=0x00`), `SRA` (`funct7=0x20`)
+- `funct3 = 0x6`: `OR`
+- `funct3 = 0x7`: `AND`
+- Multiply/divide share the `0x33` opcode with `funct7 = 0x01` and use the same `funct3` positions (`MUL`, `MULH`, `MULHSU`, `MULHU`,
+  `DIV`, `DIVU`, `REM`, `REMU`).
 
-I-type OP-IMM (opcode 0x13)
+**I-type OP-IMM (`0x13`):**
 
-- `0x0`: `ADDI`
-- `0x4`: `XORI`
-- `0x6`: `ORI`
-- `0x7`: `ANDI`
-- `0x1`: `SLLI`
-- `0x5`: `SRLI` (`0x00`) / `SRAI` (`0x20`)
+- `funct3 = 0x0`: `ADDI`
+- `funct3 = 0x1`: `SLLI`
+- `funct3 = 0x2`: `SLTI`
+- `funct3 = 0x3`: `SLTIU`
+- `funct3 = 0x4`: `XORI`
+- `funct3 = 0x5`: `SRLI` (`funct7=0x00`), `SRAI` (`funct7=0x20`)
+- `funct3 = 0x6`: `ORI`
+- `funct3 = 0x7`: `ANDI`
 
-LOADs (opcode 0x03)
+**Loads (`0x03`):** `LB` (`0x0`), `LH` (`0x1`), `LW` (`0x2`), `LBU` (`0x4`), `LHU` (`0x5`).
 
-- `0x0`: `LB`
-- `0x1`: `LH`
-- `0x2`: `LW`
-- `0x4`: `LBU`
-- `0x5`: `LHU`
+**Stores (`0x23`):** `SB` (`0x0`), `SH` (`0x1`), `SW` (`0x2`).
 
-STOREs (opcode 0x23)
+**Branches (`0x63`):** `BEQ` (`0x0`), `BNE` (`0x1`), `BLT` (`0x4`), `BGE` (`0x5`), `BLTU` (`0x6`), `BGEU` (`0x7`).
 
-- `0x0`: `SB`
-- `0x1`: `SH`
-- `0x2`: `SW`
+**`JALR` (`0x67`):** uses `funct3 = 0x0`.
 
-BRANCH (opcode 0x63)
+**System (`0x73`):** Falcon implements two encodings: `ECALL` (`0x00000073`) and `HALT` (`0x00100073`).
 
-- `0x0`: `BEQ`
-- `0x1`: `BNE`
-- `0x4`: `BLT`
-- `0x5`: `BGE`
-- `0x6`: `BLTU`
-- `0x7`: `BGEU`
+## Assembler behaviour and pseudo-instructions
 
-JALR (opcode 0x67)
+Falcon’s assembler is intentionally lightweight so you can follow every step:
 
-- `funct3 = 0x0`
+- Two passes: the first collects labels, the second encodes instructions and resolves immediates.
+- Comments begin with `;` or `#`.
+- Instructions follow the `mnemonic rd, rs1, rs2` style with commas as separators.
+- Text, data, and BSS segments are all supported (`.text`, `.data`, `.bss`) along with directives such as `.word`, `.byte`, `.ascii`,
+  `.asciiz`, and `.space`.
+- Common pseudo-instructions expand to real RV32I encodings: `nop`, `mv`, `li` (12-bit immediates), `subi`, `j`/`jal`/`call`,
+  `jr`/`ret`, `la`, `push`, `pop`, `print`, `printStr`, `printStrLn`, `read`, `readByte`, `readHalf`, `readWord`.
 
-SYSTEM (opcode 0x73)
+If you ever wonder how a pseudo expands, assemble with `cargo run` and peek at the instruction trace; Falcon prints every decoded
+instruction so you can see the real opcodes.
 
-- `ECALL` (`0x00000073`) and `HALT` (`0x00100073`) terminate execution.
+## Syscalls you can try
 
-## Syscalls and Pseudos
+All syscalls use `a7` to choose the service and read/write data through the usual argument registers.
 
-`ecall` uses `a7` to select the syscall and `a0` for arguments.
+| `a7` value | Behaviour |
+| --- | --- |
+| `1` | `print rd`: prints the value in register `rd` (`a0` carries the register number). |
+| `2` | `printStr label`: prints a NUL-terminated string without a trailing newline. |
+| `3` | `read label`: reads a full line from stdin and stores it at `label` (NUL-terminated). |
+| `4` | `printStrLn label`: prints a NUL-terminated string followed by a newline. |
+| `64` | `readByte label`: reads an unsigned decimal or `0x`-prefixed hex number and stores one byte. |
+| `65` | `readHalf label`: same as above, storing two bytes (little-endian). |
+| `66` | `readWord label`: same parsing, storing four bytes (little-endian). |
 
-- `a7=1` — `print rd`: prints the value in `rd` (`a0=rd`).
-- `a7=2` — `printStr label`: appends the NUL-terminated string at `label` to the current console line (no newline).
-- `a7=3` — `read label`: reads a full line into memory at `label` and appends NUL.
-- `a7=4` — `printStrLn label`: appends the NUL-terminated string at `label` and then starts a new line (newline).
+For the read variants, Falcon keeps asking until a valid value fits in the requested size. Invalid input results in a friendly error
+message and the program counter does **not** advance, making it clear that execution is paused.
 
-- `a7=64` — `readByte label`: reads a number from console (decimal or `0x` hex) and stores 1 byte at `label`.
-- `a7=65` — `readHalf label`: reads a number and stores 2 bytes (little-endian) at `label`.
-- `a7=66` — `readWord label`: reads a number and stores 4 bytes (little-endian) at `label`.
-
-Input parsing for `readByte/Half/Word` accepts unsigned decimal or `0x`-prefixed hexadecimal. Values outside the target size range or invalid inputs trigger a console error and the emulator waits for a new input (PC does not advance) until a valid value is provided.
-
-Note: by pedagogical choice, `DIV/DIVU/REM/REMU` with a zero divisor stop execution with an error, instead of the RISC‑V specified quotient/remainder behavior. This is intentional to highlight error conditions.
-
-## Assembler Rules
-
-- Two passes: first collects labels; second resolves and encodes.
-- Comments: everything after `;` or `#` is ignored.
-- Separator: `instr op1, op2, op3`.
-- Supported pseudos: `nop`, `mv`, `li` (12-bit), `subi`, `j/call`, `jr/ret`, `la`, `push/pop` (uses `4(sp)`), `print`, `printStr label`, `printStrLn label`, `read label`, `readByte label`, `readHalf label`, `readWord label`.
+Ready for a deeper dive? Revisit the [Tutorial](Tutorial.md) for hands-on assembly walkthroughs, or explore the sample programs in
+`Program Examples/` to see how these encodings look in real projects.

--- a/docs/format.pt-BR.md
+++ b/docs/format.pt-BR.md
@@ -1,199 +1,201 @@
-# Falcon ASM - Referência de Codificação e ISA (RV32I)
+# Guia de formato do Falcon ASM — RV32I em linguagem direta
 
-Este documento descreve o que está implementado no Falcon ASM, um emulador educacional RISC‑V. Cobre:
+Este é o guia de bolso do Falcon ASM, nosso emulador RISC-V pensado para ensino. Use-o como referência rápida quando o
+[Tutorial-pt](Tutorial-pt.md) mostra *como* montar um programa e você quer confirmar *por que* cada instrução gera aquele código.
+Chegou aqui vindo do README e quer mergulhar nos detalhes? Bem-vindo.
 
-- formatos de instrução e campos de bits;
-- opcodes, `funct3` e `funct7` usados;
-- faixas de imediatos e requisitos de alinhamento;
-- regras do assembler de texto, incluindo rótulos, segmentos e pseudoinstruções.
+## Como aproveitar este documento
 
-## Estado Atual
+- Cada seção mantém as tabelas essenciais, acompanhadas de explicações em português claro.
+- Vá direto para [Tabelas de codificação](#tabelas-de-codificacao) quando só precisar rever o arranjo dos bits.
+- Quer entender as diretivas do assembler? Pule para [Comportamento do assembler e pseudoinstruções](#comportamento-do-assembler-e-pseudoinstrucoes).
+- Prefere aprender praticando? Leia junto com o [Tutorial-pt](Tutorial-pt.md) e teste os trechos de código conforme avança.
 
-Suporta o subconjunto essencial de RV32I:
+## Visão rápida da arquitetura
 
-- Tipo R: `ADD, SUB, AND, OR, XOR, SLL, SRL, SRA, SLT, SLTU, MUL, MULH, MULHSU, MULHU, DIV, DIVU, REM, REMU`
-- Tipo I (OP-IMM): `ADDI, ANDI, ORI, XORI, SLTI, SLTIU, SLLI, SRLI, SRAI`
-- Loads: `LB, LH, LW, LBU, LHU`
-- Stores: `SB, SH, SW`
-- Branches: `BEQ, BNE, BLT, BGE, BLTU, BGEU`
-- U/J: `LUI, AUIPC, JAL`
-- JALR
-- SYSTEM: `ECALL`, `HALT`
+O Falcon foca no subconjunto RV32I+M para que você entenda cada etapa do ciclo buscar → decodificar → executar sem distrações.
 
-Não implementado: instruções FENCE/CSR e ponto flutuante.
+- **Tamanho da palavra:** 32 bits.
+- **Endianness:** sempre little-endian (`{to,from}_le_bytes`).
+- **Program counter:** avança 4 em cada instrução; desvios e saltos usam deslocamentos relativos ao PC.
+- **Registradores:** nomes `x0…x31` com os apelidos tradicionais `zero`, `ra`, `sp`, `gp`, `tp`, `t0…t6`, `s0/fp`, `s1`, `a0…a7`,
+  `s2…s11`. Escritas em `x0/zero` são descartadas.
 
-## Tamanho de Palavra, Endianness e PC
+Ainda não implementados: instruções CSR/FENCE e qualquer extensão de ponto flutuante. Manter o escopo pequeno torna o Falcon mais
+amigável para aulas e oficinas.
 
-- Palavra: 32 bits
-- Endianness: little‑endian (`{to,from}_le_bytes`)
-- PC: avança +4 por instrução. Branches e jumps usam deslocamentos relativos ao endereço da instrução.
+## Conjunto de instruções presente no Falcon
 
-## Registradores
+| Categoria | Instruções |
+| --- | --- |
+| Tipo R | `ADD`, `SUB`, `AND`, `OR`, `XOR`, `SLL`, `SRL`, `SRA`, `SLT`, `SLTU`, `MUL`, `MULH`, `MULHSU`, `MULHU`, `DIV`, `DIVU`, `REM`, `REMU` |
+| Tipo I (OP-IMM) | `ADDI`, `ANDI`, `ORI`, `XORI`, `SLTI`, `SLTIU`, `SLLI`, `SRLI`, `SRAI` |
+| Loads | `LB`, `LH`, `LW`, `LBU`, `LHU` |
+| Stores | `SB`, `SH`, `SW` |
+| Branches | `BEQ`, `BNE`, `BLT`, `BGE`, `BLTU`, `BGEU` |
+| Superiores / saltos | `LUI`, `AUIPC`, `JAL`, `JALR` |
+| Sistema | `ECALL`, `HALT` |
 
-- Registradores `x0..x31`; escritas em `x0` são ignoradas.
-- Apelidos do assembler: `zero, ra, sp, gp, tp, t0..t6, s0/fp, s1, a0..a7, s2..s11`.
+Divisão por zero vira oportunidade de aprendizado: `DIV`, `DIVU`, `REM` e `REMU` encerram o emulador com uma mensagem clara em vez
+do resultado “arquitetado”. A interrupção evidencia que algo inesperado ocorreu.
 
-## Formatos de Instrução (32 bits)
+<a id="tabelas-de-codificacao"></a>
+## Tabelas de codificação
 
-Ex.: Tipo R
+As tabelas abaixo mostram todos os layouts de 32 bits usados no Falcon. Sempre que aparecer uma observação, ela lembra o alcance
+do imediato ou algum detalhe importante.
 
-| Campo   | Bits  | Descrição                     |
-|---------|-------|--------------------------------|
-| opcode  | [6:0] | opcode principal               |
-| rd      | [11:7]| registrador destino            |
-| funct3  |[14:12]| subtipo                        |
-| rs1     |[19:15]| registrador fonte 1            |
-| rs2     |[24:20]| registrador fonte 2            |
-| funct7  |[31:25]| subtipo adicional              |
+### Tipo R (aritmética, lógica, multiplicação/divisão)
 
-Outros formatos (I, S, B, U, J) reorganizam campos e imediatos.
+| Campo  | Bits | Descrição |
+| --- | --- | --- |
+| opcode | [6:0] | família da instrução |
+| rd     | [11:7] | registrador destino |
+| funct3 | [14:12] | subtipo |
+| rs1    | [19:15] | registrador fonte 1 |
+| rs2    | [24:20] | registrador fonte 2 |
+| funct7 | [31:25] | subtipo extra / seletor de MUL/DIV |
 
-### Tipo I (OP-IMM, LOADs e JALR)
+### Tipo I (OP-IMM, loads, `JALR`)
 
-| Campo     | Bits  |
-|-----------|-------|
-| opcode    | [6:0] |
-| rd        | [11:7]|
-| funct3    |[14:12]|
-| rs1       |[19:15]|
-| imm[11:0] |[31:20]|
+| Campo | Bits |
+| --- | --- |
+| opcode | [6:0] |
+| rd | [11:7] |
+| funct3 | [14:12] |
+| rs1 | [19:15] |
+| imm[11:0] | [31:20] |
 
-- Imediatos de 12 bits com sinal (-2048..2047)
-- Shifts (`SLLI/SRLI/SRAI`) usam `shamt` em [24:20] e `funct7` = `0x00` (`SLLI/SRLI`) ou `0x20` (`SRAI`).
+- Imediatos com sinal, variando de -2048 a 2047.
+- Shifts usam `shamt` nos bits [24:20] com `funct7 = 0x00` (`SLLI`, `SRLI`) ou `0x20` (`SRAI`).
 
-### Tipo S (Stores)
+### Tipo S (stores)
 
-| Campo     | Bits  |
-|-----------|-------|
-| opcode    | [6:0] |
-| imm[4:0]  | [11:7]|
-| funct3    |[14:12]|
-| rs1       |[19:15]|
-| rs2       |[24:20]|
-| imm[11:5] |[31:25]|
+| Campo | Bits |
+| --- | --- |
+| opcode | [6:0] |
+| imm[4:0] | [11:7] |
+| funct3 | [14:12] |
+| rs1 | [19:15] |
+| rs2 | [24:20] |
+| imm[11:5] | [31:25] |
 
-### Tipo B (Branches)
+### Tipo B (branches condicionais)
 
-| Campo     | Bits  |
-|-----------|-------|
-| opcode    | [6:0] |
-| imm[11]   | [7]   |
-| imm[4:1]  |[11:8] |
-| funct3    |[14:12]|
-| rs1       |[19:15]|
-| rs2       |[24:20]|
-| imm[10:5] |[30:25]|
-| imm[12]   |[31]   |
+| Campo | Bits |
+| --- | --- |
+| opcode | [6:0] |
+| imm[11] | [7] |
+| imm[4:1] | [11:8] |
+| funct3 | [14:12] |
+| rs1 | [19:15] |
+| rs2 | [24:20] |
+| imm[10:5] | [30:25] |
+| imm[12] | [31] |
 
-- Imediatos de 13 bits (em bytes) com bit0 = 0. O assembler calcula `target_pc - instruction_pc`.
+- O assembler preenche um imediato de 13 bits (em bytes). O bit 0 é sempre zero, pois o alvo precisa estar alinhado em palavras.
 
-### Tipo U (LUI/AUIPC)
+### Tipo U (`LUI`, `AUIPC`)
 
-| Campo     | Bits  |
-|-----------|-------|
-| opcode    | [6:0] |
-| rd        |[11:7] |
-| imm[31:12]|[31:12]|
+| Campo | Bits |
+| --- | --- |
+| opcode | [6:0] |
+| rd | [11:7] |
+| imm[31:12] | [31:12] |
 
-### Tipo J (JAL)
+### Tipo J (`JAL`)
 
-| Campo     | Bits  |
-|-----------|-------|
-| opcode    | [6:0] |
-| rd        |[11:7] |
-| imm[19:12]|[19:12]|
-| imm[11]   | [20]  |
-| imm[10:1] |[30:21]|
-| imm[20]   | [31]  |
+| Campo | Bits |
+| --- | --- |
+| opcode | [6:0] |
+| rd | [11:7] |
+| imm[19:12] | [19:12] |
+| imm[11] | [20] |
+| imm[10:1] | [30:21] |
+| imm[20] | [31] |
 
-- Imediatos de 21 bits (em bytes) com bit0 = 0. O assembler calcula o deslocamento relativo.
+- Imediato de 21 bits armazenado em bytes; o bit 0 fica em zero porque os alvos também são alinhados em palavras.
 
-## Opcodes por tipo
+## Referência de opcode e funct
 
-- `OPC_RTYPE = 0x33`
-- `OPC_OPIMM = 0x13`
-- `OPC_LOAD  = 0x03`
-- `OPC_STORE = 0x23`
-- `OPC_BRANCH= 0x63`
-- `OPC_LUI   = 0x37`
-- `OPC_AUIPC = 0x17`
-- `OPC_JAL   = 0x6F`
-- `OPC_JALR  = 0x67`
-- `OPC_SYSTEM= 0x73`
+| Uso | Valor |
+| --- | --- |
+| `OPC_RTYPE` | `0x33` |
+| `OPC_OPIMM` | `0x13` |
+| `OPC_LOAD` | `0x03` |
+| `OPC_STORE` | `0x23` |
+| `OPC_BRANCH` | `0x63` |
+| `OPC_LUI` | `0x37` |
+| `OPC_AUIPC` | `0x17` |
+| `OPC_JAL` | `0x6F` |
+| `OPC_JALR` | `0x67` |
+| `OPC_SYSTEM` | `0x73` |
 
-## FUNCT3/FUNCT7
+### `funct3` e `funct7`
 
-Tipo R (opcode 0x33)
+**Tipo R (`0x33`):**
 
-- `0x0`: `ADD` (`funct7=0x00`), `SUB` (`funct7=0x20`)
-- `0x1`: `SLL`
-- `0x4`: `XOR`
-- `0x5`: `SRL` (`0x00`), `SRA` (`0x20`)
-- `0x6`: `OR`
-- `0x7`: `AND`
+- `funct3 = 0x0`: `ADD` (`funct7=0x00`), `SUB` (`funct7=0x20`)
+- `funct3 = 0x1`: `SLL`
+- `funct3 = 0x2`: `SLT`
+- `funct3 = 0x3`: `SLTU`
+- `funct3 = 0x4`: `XOR`
+- `funct3 = 0x5`: `SRL` (`funct7=0x00`), `SRA` (`funct7=0x20`)
+- `funct3 = 0x6`: `OR`
+- `funct3 = 0x7`: `AND`
+- Multiplicação/divisão usam `funct7 = 0x01` com os mesmos `funct3`: `MUL`, `MULH`, `MULHSU`, `MULHU`, `DIV`, `DIVU`, `REM`, `REMU`.
 
-Tipo I OP-IMM (opcode 0x13)
+**Tipo I OP-IMM (`0x13`):**
 
-- `0x0`: `ADDI`
-- `0x4`: `XORI`
-- `0x6`: `ORI`
-- `0x7`: `ANDI`
-- `0x1`: `SLLI`
-- `0x5`: `SRLI` (`0x00`) / `SRAI` (`0x20`)
+- `funct3 = 0x0`: `ADDI`
+- `funct3 = 0x1`: `SLLI`
+- `funct3 = 0x2`: `SLTI`
+- `funct3 = 0x3`: `SLTIU`
+- `funct3 = 0x4`: `XORI`
+- `funct3 = 0x5`: `SRLI` (`funct7=0x00`), `SRAI` (`funct7=0x20`)
+- `funct3 = 0x6`: `ORI`
+- `funct3 = 0x7`: `ANDI`
 
-LOADs (opcode 0x03)
+**Loads (`0x03`):** `LB` (`0x0`), `LH` (`0x1`), `LW` (`0x2`), `LBU` (`0x4`), `LHU` (`0x5`).
 
-- `0x0`: `LB`
-- `0x1`: `LH`
-- `0x2`: `LW`
-- `0x4`: `LBU`
-- `0x5`: `LHU`
+**Stores (`0x23`):** `SB` (`0x0`), `SH` (`0x1`), `SW` (`0x2`).
 
-STOREs (opcode 0x23)
+**Branches (`0x63`):** `BEQ` (`0x0`), `BNE` (`0x1`), `BLT` (`0x4`), `BGE` (`0x5`), `BLTU` (`0x6`), `BGEU` (`0x7`).
 
-- `0x0`: `SB`
-- `0x1`: `SH`
-- `0x2`: `SW`
+**`JALR` (`0x67`):** usa `funct3 = 0x0`.
 
-BRANCH (opcode 0x63)
+**System (`0x73`):** o Falcon implementa dois códigos: `ECALL` (`0x00000073`) e `HALT` (`0x00100073`).
 
-- `0x0`: `BEQ`
-- `0x1`: `BNE`
-- `0x4`: `BLT`
-- `0x5`: `BGE`
-- `0x6`: `BLTU`
-- `0x7`: `BGEU`
+<a id="comportamento-do-assembler-e-pseudoinstrucoes"></a>
+## Comportamento do assembler e pseudoinstruções
 
-JALR (opcode 0x67)
+O assembler do Falcon é direto justamente para que você acompanhe cada passo:
 
-- `funct3 = 0x0`
+- Duas passagens: a primeira coleta rótulos, a segunda resolve e codifica as instruções.
+- Comentários começam em `;` ou `#`.
+- As instruções seguem `mnemonic rd, rs1, rs2`, com vírgulas separando os operandos.
+- Segmentos `.text`, `.data` e `.bss` são aceitos, junto com diretivas como `.word`, `.byte`, `.ascii`, `.asciiz` e `.space`.
+- Pseudoinstruções comuns expandem para RV32I real: `nop`, `mv`, `li` (imediatos de 12 bits), `subi`, `j`/`jal`/`call`,
+  `jr`/`ret`, `la`, `push`, `pop`, `print`, `printStr`, `printStrLn`, `read`, `readByte`, `readHalf`, `readWord`.
 
-SYSTEM (opcode 0x73)
+Quer ver a expansão? Rode `cargo run`, monte o programa e acompanhe o traço de instruções: o Falcon imprime cada decodificação.
 
-- `ECALL` (`0x00000073`) e `HALT` (`0x00100073`) encerram a execução.
+## Syscalls disponíveis
 
-## Syscalls e Pseudos
+Todas as chamadas usam `a7` para selecionar o serviço e os registradores de argumento padrão para dados.
 
-`ecall` usa `a7` para selecionar a chamada de sistema e `a0` para argumentos.
+| Valor em `a7` | Comportamento |
+| --- | --- |
+| `1` | `print rd`: imprime o valor do registrador `rd` (o número do registrador vem em `a0`). |
+| `2` | `printStr label`: imprime uma string NUL-terminada sem quebra de linha. |
+| `3` | `read label`: lê uma linha da entrada padrão e armazena em `label` (com NUL ao final). |
+| `4` | `printStrLn label`: imprime a string NUL-terminada e adiciona uma quebra de linha. |
+| `64` | `readByte label`: aceita número decimal ou hexadecimal (`0x`) e grava um byte. |
+| `65` | `readHalf label`: mesma leitura, gravando dois bytes (little-endian). |
+| `66` | `readWord label`: idem, armazenando quatro bytes (little-endian). |
 
-- `a7=1` — `print rd`: imprime o valor de `rd` (`a0=rd`).
-- `a7=2` — `printStr label`: concatena a string NUL-terminada em `label` na linha atual do console (sem quebra de linha).
-- `a7=3` — `read label`: lê uma linha do console para a memória em `label` e adiciona NUL.
-- `a7=4` — `printStrLn label`: concatena a string NUL-terminada e inicia nova linha (com quebra).
+Nos modos de leitura, o Falcon insiste até receber um valor válido para o tamanho pedido. Entradas inválidas geram uma mensagem
+amigável e o PC **não** avança, destacando que a execução está em pausa.
 
-- `a7=64` — `readByte label`: lê um número (decimal ou `0x`hex) e armazena 1 byte em `label`.
-- `a7=65` — `readHalf label`: lê um número e armazena 2 bytes (little-endian) em `label`.
-- `a7=66` — `readWord label`: lê um número e armazena 4 bytes (little-endian) em `label`.
-
-Tratamento de overflow/erros: para `readByte/Half/Word` valores fora da faixa do tamanho alvo ou entradas inválidas geram uma mensagem de erro no console e o emulador volta a aguardar uma nova entrada (o PC não avança) até que um valor válido seja fornecido.
-
-Observação: por escolha pedagógica, `DIV/DIVU/REM/REMU` com divisor zero interrompem a execução com erro, em vez do comportamento padrão do RISC‑V. Isso é intencional para evidenciar condições de erro.
-
-## Regras do Assembler
-
-- Duas passagens: a primeira coleta rótulos (`label:`); a segunda resolve e codifica.
-- Comentários: tudo após `;` ou `#` é ignorado.
-- Separador: `instr op1, op2, op3`.
-- Pseudos suportadas: `nop`, `mv`, `li` (12 bits), `subi`, `j/call`, `jr/ret`, `la`, `push/pop` (usa `4(sp)`), `print`, `printStr label`, `printStrLn label`, `read label`, `readByte label`, `readHalf label`, `readWord label`.
-
-
+Pronto para ir além? Retorne ao [Tutorial-pt](Tutorial-pt.md) para ver exemplos guiados ou explore `Program Examples/` e enxergue
+essas codificações em programas reais.


### PR DESCRIPTION
## Summary
- highlight Falcon's IDE-like simulator experience in both English and Portuguese READMEs
- clarify that each README links to its matching tutorial and format guides
