### PR TITLE
Publish multi-platform release artifacts to GitHub Releases

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -59,15 +59,34 @@ jobs:
         run: |
           mkdir -p release-artifacts
           bin="target/${{ matrix.target }}/release/falconasm"
-          out="release-artifacts/falconasm-${{ matrix.target }}"
+          name="falconasm-${{ matrix.target }}"
           if [[ "${{ matrix.target }}" == *"windows"* ]]; then
             bin="${bin}.exe"
-            out="${out}.exe"
+            zip -j "release-artifacts/${name}.zip" "$bin"
+          else
+            tar -czf "release-artifacts/${name}.tar.gz" -C "$(dirname "$bin")" "$(basename "$bin")"
           fi
-          cp "$bin" "$out"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: falconasm-${{ matrix.target }}
           path: release-artifacts/
+
+  release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: falconasm-*
+          path: release-dist
+          merge-multiple: true
+
+      - name: Publish release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-dist/**


### PR DESCRIPTION
### Motivation
- Ensure release builds produce platform-friendly archives instead of raw binaries for easier distribution.
- Automate publishing of built artifacts to GitHub Releases when a tag is pushed.
- Support the existing build matrix (Linux, Windows, macOS, x86_64 and aarch64) and cross builds where needed.

### Description
- Change `Package artifact` step in `.github/workflows/release-build.yml` to create a `.zip` for Windows targets and a `.tar.gz` for other targets instead of copying the raw binary.
- Introduce a new `release` job that runs only for tag refs and depends on the `build` job, which downloads artifacts with `actions/download-artifact@v4` and publishes them with `softprops/action-gh-release@v2`.
- Artifacts are stored under `release-artifacts` during the build and downloaded into `release-dist` for publishing, using `merge-multiple: true` to combine matrix outputs.
- Retain the existing matrix and build steps including use of `cross` for cross-compilation where configured.

### Testing
- No automated tests were executed for this workflow-only change (CI workflows were not run during the update).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696586c6367483339de9dd95c47a534d)